### PR TITLE
Only matches pages that have a version number in the URL.

### DIFF
--- a/django_docs_version_switcher/version_switcher.coffee
+++ b/django_docs_version_switcher/version_switcher.coffee
@@ -6,7 +6,7 @@ $(document).ready ->
     $('ul#doc-versions a').click ->
         localStorage.django_version = $(this).html()
 
-regex = new RegExp("docs.djangoproject.com/[^/]*/([^/]*)")
+regex = new RegExp("docs.djangoproject.com/[^/]*/([0-9]+\.[0-9]+|dev)/")
 match = regex.exec window.location
 
 if match and match[1] != localStorage.django_version


### PR DESCRIPTION
Fixes error caused by incorrectly redirecting the search results page.

Bear in mind that I changed this in the GitHub web UI, so I have not tested it. Also, you must compile the CoffeScript to JavaScript. Sorry about that.
